### PR TITLE
Option to make comments and posts non-interactable, bug fixes, hide "give awards" button

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,11 @@ I'm sure I'm not the only one annoyed by the awards on Reddit. So I created this
 -   works on redesigned and old version of Reddit
 -   disable awards on posts and comments
 -   disable animated awards on comments
--   disable awards on RPAN <sup>**NEW**</sup>
--   settings pop-up to customize which awards to show (for example: _show awards on RPAN, but not on comments and posts_) <sup>**NEW**</sup>
+-   disable awards on RPAN
+-   settings pop-up to customize which awards to show (for example: _show awards on RPAN, but not on comments and posts_)
+-   hide "Give Awards" on comments and posts <sup>**NEW**</sup>
+-   hide "Coins X" on your profile dropdown <sup>**NEW**</sup>
+-   option to show all awards but make them non-interactive <sup>**NEW**</sup>
 
 ## Settings pop-up:
 
@@ -23,7 +26,7 @@ I'm sure I'm not the only one annoyed by the awards on Reddit. So I created this
 
 While I'm not available to make this work on mobile, there are a lot of **unofficial Reddit apps** for download and some of them have an option to hide awards, to name a few:
 
--   Rif is fun [Android](https://www.play.google.com/store/apps/details?id=com.andrewshu.android.reddit)
+-   Rif is fun [Android](https://play.google.com/store/apps/details?id=com.andrewshu.android.reddit)
 -   Sync [Android](https://play.google.com/store/apps/details?id=com.laurencedawson.reddit_sync)
 -   Boost [Android](https://play.google.com/store/apps/details?id=com.rubenmayayo.reddit)
 -   Slide [Android](https://play.google.com/store/apps/details?id=me.ccrama.redditslide) & [iOS](https://apps.apple.com/us/app/slide-for-reddit/id1260626828)

--- a/css/getCoinsBtn.css
+++ b/css/getCoinsBtn.css
@@ -2,10 +2,14 @@
     hide "get coins" button at the navigation bar
     NEW REDDIT
 */
-._1t5i5bNwZeJ7FuUXZ9rM-p {
-	display: none;
+#COIN_PURCHASE_DROPDOWN_ID {
+	display: none !important;
 }
 
-._1t5i5bNwZeJ7FuUXZ9rM-p._1dJtiWITrnvIbQdXgYgdym {
+/*
+    hide "Coins X" on user settings menu/dropdown
+    NEW REDDIT
+*/
+._3zu1R6cDitNjrJaFA1VPXj._3fbofimxVp_hpVM6I1TGMS {
 	display: none !important;
 }

--- a/css/giveAwardsBtn.css
+++ b/css/giveAwardsBtn.css
@@ -25,3 +25,13 @@
 .give-gold-button {
 	display: none !important;
 }
+
+/*
+    hide "give award" button on comments
+    NEW REDDIT
+*/
+
+.XZK-LTFT5CgGo9MvPQQsy._1LXnp2ufrzN6ioaTLTjGQ1._3rHRwVOKmBBlBOQ4kIW_vq._2_lhaFUJdP8q0o2L9MN2TN
+	> ._374Hkkigy4E4srsI2WktEd._2hr3tRWszeMRQ0u_Whs7t8._14hLFU5cIJCyxH9DSgsCov:nth-child(2) {
+	display: none;
+}

--- a/css/giveAwardsBtn.css
+++ b/css/giveAwardsBtn.css
@@ -30,8 +30,15 @@
     hide "give award" button on comments
     NEW REDDIT
 */
-
 .XZK-LTFT5CgGo9MvPQQsy._1LXnp2ufrzN6ioaTLTjGQ1._3rHRwVOKmBBlBOQ4kIW_vq._2_lhaFUJdP8q0o2L9MN2TN
 	> ._374Hkkigy4E4srsI2WktEd._2hr3tRWszeMRQ0u_Whs7t8._14hLFU5cIJCyxH9DSgsCov:nth-child(2) {
 	display: none;
+}
+
+/*
+    hide award icon next to user name/other awards on posts and comments
+    NEW REDDIT
+*/
+._1vpnHb2bSTD6BcgVKisnPT._3vGYJIJIswDD8YOAMWGC4N {
+	display: none !important;
 }

--- a/css/notInteractableAwards.css
+++ b/css/notInteractableAwards.css
@@ -1,0 +1,15 @@
+/*
+	awards on posts and comments
+	NEW REDDIT
+*/
+._2OYwDdghtXEuTF67C95YLY {
+	pointer-events: none;
+}
+
+/*
+	awards on posts and comments
+	OLD REDDIT	
+*/
+.awarding-link {
+	pointer-events: none;
+}

--- a/css/rpanAwards.css
+++ b/css/rpanAwards.css
@@ -18,7 +18,7 @@
 }
 
 .Qkdtf2CTKJDknbazL-AMW:after {
-	content: 'removed by "No awards for Reddit" extension' !important;
+	content: 'Award removed by "No awards for Reddit" extension' !important;
 	font-size: 12px !important;
 	font-style: italic !important;
 	color: lightgray !important;

--- a/handle-settings.js
+++ b/handle-settings.js
@@ -5,6 +5,9 @@ const saveSettings = async () => {
 	const COMMENTS_AND_POSTS_AWARDS =
 		document.getElementById("toggle-op3").checked;
 	const GET_COINS_BTN = document.getElementById("toggle-op4").checked;
+	const NOT_INTERACTABLE_AWARDS = document.getElementById(
+		"toggle-notInteractableAwards"
+	).checked;
 
 	// save select elements :checked value to browser local storage
 	await chrome.storage.local.set(
@@ -13,6 +16,7 @@ const saveSettings = async () => {
 			rpanAwards: RPAN_AWARDS,
 			commentsAndPostsAwards: COMMENTS_AND_POSTS_AWARDS,
 			getCoinsBtn: GET_COINS_BTN,
+			notInteractableAwards: NOT_INTERACTABLE_AWARDS,
 		},
 		() => {
 			setTimeout(() => {
@@ -42,6 +46,7 @@ const loadSettings = async () => {
 			rpanAwards: true,
 			commentsAndPostsAwards: true,
 			getCoinsBtn: false,
+			notInteractableAwards: false,
 		},
 		(settings) => {
 			document.getElementById("toggle-op1").checked =
@@ -51,6 +56,8 @@ const loadSettings = async () => {
 				settings.commentsAndPostsAwards;
 			document.getElementById("toggle-op4").checked =
 				settings.getCoinsBtn;
+			document.getElementById("toggle-notInteractableAwards").checked =
+				settings.notInteractableAwards;
 		}
 	);
 };

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 	"version": "2.2.0",
 
 	"name": "No awards for Reddit",
-	"description": "Hide awards on posts and comments for redesigned and also old Reddit.",
+	"description": "Hide awards all over the redesigned and old Reddit (on posts, comments, RPAN streams and more)",
 	"author": "datguysheepy",
 
 	"icons": {

--- a/manifest.json
+++ b/manifest.json
@@ -33,10 +33,10 @@
 	],
 
 	"web_accessible_resources": [
-		"css/no-awards.css",
 		"css/commentsAndPostsAwards.css",
 		"css/rpanAwards.css",
 		"css/getCoinsBtn.css",
-		"css/giveAwardsBtn.css"
+		"css/giveAwardsBtn.css",
+		"css/test.css"
 	]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
 	"manifest_version": 2,
-	"version": "2.1.0",
+	"version": "2.2.0",
 
 	"name": "No awards for Reddit",
 	"description": "Hide awards on posts and comments for redesigned and also old Reddit.",

--- a/no-awards-menu.html
+++ b/no-awards-menu.html
@@ -18,7 +18,7 @@
 			.ext-menu-wrap {
 				display: flex;
 				flex-direction: column;
-				width: 280px;
+				min-width: 290px;
 			}
 
 			.ext-menu-header {
@@ -242,6 +242,26 @@
 						class="toggle-checkbox"
 					/>
 					<label for="toggle-op4" class="toggle-label"></label>
+				</div>
+			</div>
+
+			<h1 class="ext-menu-header">Extra settings:</h1>
+
+			<div class="op-wrap">
+				<label for="toggle-notInteractableAwards" class="op-label">
+					Make awards not-interactable
+				</label>
+				<div class="toggle-wrap">
+					<input
+						type="checkbox"
+						name="toggle"
+						id="toggle-notInteractableAwards"
+						class="toggle-checkbox"
+					/>
+					<label
+						for="toggle-notInteractableAwards"
+						class="toggle-label"
+					></label>
 				</div>
 			</div>
 

--- a/no-awards.js
+++ b/no-awards.js
@@ -14,6 +14,7 @@ const loadStyling = async () => {
 			rpanAwards: true,
 			commentsAndPostsAwards: true,
 			getCoinsBtn: false,
+			notInteractableAwards: false,
 		},
 		(userSettings) => {
 			Object.entries(userSettings).forEach(([key, checked]) => {


### PR DESCRIPTION
- added new option to make the awards on comments and posts non-interactable as requested by one of the users of this extension (thanks for the suggestion :)).
- "Give Award" button should be hidden now both on posts and comments.
- "Coins X" button on user profile dropdown should also be hidden now.
- bug fixes to other existing options.